### PR TITLE
Fix dicarding a policy

### DIFF
--- a/utils/RoomsManager.js
+++ b/utils/RoomsManager.js
@@ -486,7 +486,7 @@ class RoomsManager {
     }
     discardPolicy(roomName, card) {
         const { drawnCards, discardPile } = this.rooms_props[roomName]
-        this.moveCard(drawnCards, discardPile)
+        this.moveCard(drawnCards, discardPile, card)
     }
 
     discardAllCards(roomName) {

--- a/utils/__tests__/RoomsManager.spec.js
+++ b/utils/__tests__/RoomsManager.spec.js
@@ -499,6 +499,18 @@ describe('RoomsManager', () => {
         })
     })
 
+    const checkIfRoomsCardsMatch = (first, second) => checkIfCardsMatch(
+        [
+            ...first.drawPile,
+            ...first.discardPile,
+            ...first.drawnCards,
+        ], [
+            ...second.drawPile,
+            ...second.discardPile,
+            ...second.drawnCards,
+        ],
+    )
+
     describe('reShuffle', () => {
         test('The same cards stay after reShuffle', () => {
             RoomsManager.drawPile = [PolicyCards.FacistPolicy, PolicyCards.LiberalPolicy]
@@ -516,17 +528,6 @@ describe('RoomsManager', () => {
     })
 
     describe('takeChoicePolicyCards', () => {
-        const checkIfRoomsCardsMatch = (first, second) => checkIfCardsMatch(
-            [
-                ...first.drawPile,
-                ...first.discardPile,
-                ...first.drawnCards,
-            ], [
-                ...second.drawPile,
-                ...second.discardPile,
-                ...second.drawnCards,
-            ]
-        )
         test('Should take 1 out of 4 cards', () => {
             RoomsManager.rooms_props['testRoom'].drawPile = [
                 PolicyCards.FacistPolicy,
@@ -664,6 +665,74 @@ describe('RoomsManager', () => {
             expect(checkIfCardsMatch(
                 [ PolicyCards.FacistPolicy, PolicyCards.FacistPolicy, PolicyCards.LiberalPolicy ],
                 RoomsManager.rooms_props['testRoom'].drawnCards,
+            )).toEqual(true)
+        })
+    })
+
+    describe('discardPolicy', () => {
+        test(`If no card is passed then it reports error, any pile isn't changed`, () => {
+            const { testRoom } = RoomsManager.rooms_props;
+            testRoom.drawPile = [
+                ...times(3, () => PolicyCards.FacistPolicy),
+                ...times(2, () => PolicyCards.LiberalPolicy),
+            ]
+            const initialRoomProps = cloneDeep(testRoom)
+
+            RoomsManager.discardPolicy('testRoom', undefined)
+            expect(checkIfRoomsCardsMatch(
+                initialRoomProps,
+                testRoom,
+            )).toEqual(true)
+
+            expect(checkIfCardsMatch(
+                initialRoomProps.drawPile,
+                testRoom.drawPile,
+            )).toEqual(true)
+
+            expect(checkIfCardsMatch(
+                initialRoomProps.discardPile,
+                testRoom.discardPile,
+            )).toEqual(true)
+        })
+
+        test('Should move chosen card from drawn cards pile to discard pile', () => {
+            const testRoom = RoomsManager.rooms_props.testRoom
+            testRoom.drawPile = [
+                ...times(3, () => PolicyCards.FacistPolicy),
+                ...times(2, () => PolicyCards.LiberalPolicy),
+            ]
+            const initialRoomProps = cloneDeep(testRoom)
+
+            RoomsManager.discardPolicy('testRoom', testRoom.drawPile[3])
+            expect(checkIfRoomsCardsMatch(
+                initialRoomProps,
+                testRoom,
+            )).toEqual(true)
+        })
+
+        test('If card does not exist in draw pile, then error is reported and any pile is not changed', () => {
+            const { testRoom } = RoomsManager.rooms_props;
+            testRoom.drawPile = [
+                ...times(3, () => PolicyCards.FacistPolicy),
+            ]
+            const notPresentCard = PolicyCards.LiberalPolicy
+            const initialRoomProps = cloneDeep(testRoom)
+
+            RoomsManager.discardPolicy('testRoom', notPresentCard)
+
+            expect(checkIfRoomsCardsMatch(
+                initialRoomProps,
+                testRoom,
+            )).toEqual(true)
+
+            expect(checkIfCardsMatch(
+                initialRoomProps.drawPile,
+                testRoom.drawPile,
+            )).toEqual(true)
+
+            expect(checkIfCardsMatch(
+                initialRoomProps.discardPile,
+                testRoom.discardPile,
             )).toEqual(true)
         })
     })


### PR DESCRIPTION
I was testing another branch and I discovered another bug with policies.
It turned out that magicly chancellor can have choice from three cards:
![chancellorhasthreecards](https://user-images.githubusercontent.com/17849844/40027301-b44f423a-57d9-11e8-8d1e-109971a3d035.png)
Logs from server lucky showed a way to resolve the issue:
![chancellorhastreecards](https://user-images.githubusercontent.com/17849844/40027331-d012c118-57d9-11e8-8d2c-e8506eef0915.png)

