### PR TITLE
Trigger superpowers after fascist policy enacted by tracker

### DIFF
--- a/events/PhaseSocketEvents.js
+++ b/events/PhaseSocketEvents.js
@@ -47,6 +47,7 @@ const PhaseSocketEvents = (io, RoomsManager) => {
         },
 
         startChancellorChoicePhase: (socket, designatedPresidentName = null) => {
+            if (RoomsManager.getGamePhase(socket.currentRoom) === GamePhases.GAME_PHASE_SUPERPOWER) return
             RoomsManager.startChancellorChoicePhase(socket.currentRoom, designatedPresidentName)
             const playersChoices = RoomsManager.getChancellorChoices(socket.currentRoom)
 

--- a/events/SocketEvents.js
+++ b/events/SocketEvents.js
@@ -272,8 +272,6 @@ module.exports = function (io) {
             const isVetoUnlocked = RoomsManager.isVetoUnlocked(socket.currentRoom)
             if (isVetoUnlocked) {
                 socketEvents.triggerVetoPrompt(socket)
-            } else if (choice === PolicyCards.FacistPolicy) {
-                checkForImmediateSuperpowersOrContinue(socket)
             } else {
                 const shouldGameFinish = phaseSocketEvents.checkIfGameShouldFinish(socket)
                 if (!shouldGameFinish) {

--- a/events/SocketEvents.js
+++ b/events/SocketEvents.js
@@ -104,7 +104,7 @@ module.exports = function (io) {
                 socketEventsUtils.sendMessage(socket, { content: `The ${roleString} invoked veto for the enacted policy as well! The enacted policy has been rejected!` })
                 socketEventsUtils.clearNextPhaseTimeout()
                 RoomsManager.discardPolicyByVeto(socket.currentRoom)
-                socketEventsUtils.checkIfTrackerPositionShouldUpdate(socket, false)
+                socketEventsUtils.updateTrackerPositionIfNecessary(socket, false)
 
                 const shouldGameFinish = phaseSocketEvents.checkIfGameShouldFinish(socket)
                 if (!shouldGameFinish) {
@@ -244,7 +244,7 @@ module.exports = function (io) {
                 `
                 socketEventsUtils.sendMessage(socket, { content: votingResultMessage })
 
-                socketEventsUtils.checkIfTrackerPositionShouldUpdate(socket, hasVotingSucceed)
+                socketEventsUtils.updateTrackerPositionIfNecessary(socket, hasVotingSucceed)
 
                 if (hasVotingSucceed) {
                     RoomsManager.setChancellor(socket.currentRoom)

--- a/events/SocketEvents.js
+++ b/events/SocketEvents.js
@@ -20,38 +20,16 @@ const ClientVerificationHof = require('../utils/ClientVerificationHof')
 const RoomsManager = new (require('../utils/RoomsManager'))()
 const SocketEventsUtils = require('../utils/SocketEventsUtils')
 const PhaseSocketEvents = require('./PhaseSocketEvents')
+const EnactPolicyModule = require('./enactPolicy')
 
 module.exports = function (io) {
-    const socketEventsUtils = SocketEventsUtils(io, RoomsManager)
     const phaseSocketEvents = PhaseSocketEvents(io, RoomsManager)
+    const socketEventsUtils = SocketEventsUtils(io, RoomsManager)
+    const {
+        enactPolicy, checkForImmediateSuperpowersOrContinue,
+        updateTrackerPositionIfNecessary,
+    } = EnactPolicyModule(io, RoomsManager, phaseSocketEvents, socketEventsUtils)
     const socketEvents = {
-        checkForImmediateSuperpowersOrContinue: (socket) => {
-            const fascistPolicyCount = RoomsManager.getPolicyCardsCount(socket.currentRoom, PolicyCards.FacistPolicy)
-            const playerboardType = RoomsManager.getPlayerboardType(socket.currentRoom)
-            if (fascistPolicyCount === 1 && playerboardType === PlayerBoards.LargeBoard) {
-                phaseSocketEvents.startPeekAffiliationSuperpowerPhase(socket)
-            } else if (fascistPolicyCount === 2 && playerboardType !== PlayerBoards.SmallBoard) {
-                phaseSocketEvents.startPeekAffiliationSuperpowerPhase(socket)
-            } else if (fascistPolicyCount === 3) {
-                if (playerboardType === PlayerBoards.SmallBoard) {
-                    // President will see top 3 cards from the drawPile deck
-                    phaseSocketEvents.startPeekCardsPhase(socket)
-                } else {
-                    // President will designate next president superpower
-                    phaseSocketEvents.startDesignateNextPresidentPhase(socket)
-                }
-            // 4th power is always kill on each board
-            } else if (fascistPolicyCount === 4) {
-                phaseSocketEvents.startKillPhase(socket)
-            // 5th power is always kill AND veto power unlock
-            } else if (fascistPolicyCount === 5) {
-                RoomsManager.toggleVeto(socket.currentRoom)
-                socketEventsUtils.sendMessage(socket, { content: 'The veto power has been unlocked! Now president or chancellor can veto any enacted policy!' })
-                phaseSocketEvents.startKillPhase(socket)
-            } else {
-                socketEventsUtils.resumeGame(socket, { delay: 3000, func: phaseSocketEvents.startChancellorChoicePhase })
-            }
-        },
         triggerVetoPrompt: (socket) => {
             RoomsManager.setGamePhase(socket.currentRoom, GamePhases.ServerWaitingForVeto)
             RoomsManager.clearVetoVotes(socket.currentRoom)
@@ -104,7 +82,7 @@ module.exports = function (io) {
                 socketEventsUtils.sendMessage(socket, { content: `The ${roleString} invoked veto for the enacted policy as well! The enacted policy has been rejected!` })
                 socketEventsUtils.clearNextPhaseTimeout()
                 RoomsManager.discardPolicyByVeto(socket.currentRoom)
-                socketEventsUtils.updateTrackerPositionIfNecessary(socket, false)
+                updateTrackerPositionIfNecessary(socket, false)
 
                 const shouldGameFinish = phaseSocketEvents.checkIfGameShouldFinish(socket)
                 if (!shouldGameFinish) {
@@ -244,7 +222,7 @@ module.exports = function (io) {
                 `
                 socketEventsUtils.sendMessage(socket, { content: votingResultMessage })
 
-                socketEventsUtils.updateTrackerPositionIfNecessary(socket, hasVotingSucceed)
+                updateTrackerPositionIfNecessary(socket, hasVotingSucceed)
 
                 if (hasVotingSucceed) {
                     RoomsManager.setChancellor(socket.currentRoom)
@@ -289,13 +267,13 @@ module.exports = function (io) {
         },
 
         choosePolicyChancellor: (socket, choice) => {
-            socketEventsUtils.enactPolicy(socket, choice)
+            enactPolicy(socket, choice)
 
             const isVetoUnlocked = RoomsManager.isVetoUnlocked(socket.currentRoom)
             if (isVetoUnlocked) {
                 socketEvents.triggerVetoPrompt(socket)
             } else if (choice === PolicyCards.FacistPolicy) {
-                socketEvents.checkForImmediateSuperpowersOrContinue(socket)
+                checkForImmediateSuperpowersOrContinue(socket)
             } else {
                 const shouldGameFinish = phaseSocketEvents.checkIfGameShouldFinish(socket)
                 if (!shouldGameFinish) {

--- a/events/enactPolicy.js
+++ b/events/enactPolicy.js
@@ -1,0 +1,73 @@
+const { PolicyCards, PlayerBoards, SocketEvents } = require('../Dictionary')
+const { getCurrentTimestamp } = require('../utils/utils')
+
+module.exports = function (io, RoomsManager, phaseSocketEvents, socketEventsUtils) {
+    const policyLogic = {
+        updateTrackerPositionIfNecessary: (socket, isSuccess) => {
+            if (isSuccess) {
+                const trackerPosition = RoomsManager.getFailedElectionsCount(socket.currentRoom)
+                socketEventsUtils.resetElectionTracker(socket, trackerPosition)
+            } else {
+                RoomsManager.increaseFailedElectionsCount(socket.currentRoom)
+                socketEventsUtils.sendMessage(socket, { content: 'The failed elections tracker has increased!' })
+                const failedElectionsCount = RoomsManager.getFailedElectionsCount(socket.currentRoom)
+                if (failedElectionsCount >= 3) {
+                    socketEventsUtils.resetElectionTracker(socket, failedElectionsCount)
+
+                    const topCard = RoomsManager.takeChoicePolicyCards(socket.currentRoom, 1)[0]
+                    policyLogic.enactPolicy(socket, topCard)
+                } else {
+                    io.sockets.in(socket.currentRoom).emit(SocketEvents.IncreaseTrackerPosition, {
+                        data: {
+                            timestamp: getCurrentTimestamp(),
+                        },
+                    })
+                }
+            }
+        },
+
+        checkForImmediateSuperpowersOrContinue: (socket) => {
+            const fascistPolicyCount = RoomsManager.getPolicyCardsCount(socket.currentRoom, PolicyCards.FacistPolicy)
+            const playerboardType = RoomsManager.getPlayerboardType(socket.currentRoom)
+            if (fascistPolicyCount === 1 && playerboardType === PlayerBoards.LargeBoard) {
+                phaseSocketEvents.startPeekAffiliationSuperpowerPhase(socket)
+            } else if (fascistPolicyCount === 2 && playerboardType !== PlayerBoards.SmallBoard) {
+                phaseSocketEvents.startPeekAffiliationSuperpowerPhase(socket)
+            } else if (fascistPolicyCount === 3) {
+                if (playerboardType === PlayerBoards.SmallBoard) {
+                    // President will see top 3 cards from the drawPile deck
+                    phaseSocketEvents.startPeekCardsPhase(socket)
+                } else {
+                    // President will designate next president superpower
+                    phaseSocketEvents.startDesignateNextPresidentPhase(socket)
+                }
+                // 4th power is always kill on each board
+            } else if (fascistPolicyCount === 4) {
+                phaseSocketEvents.startKillPhase(socket)
+                // 5th power is always kill AND veto power unlock
+            } else if (fascistPolicyCount === 5) {
+                RoomsManager.toggleVeto(socket.currentRoom)
+                socketEventsUtils.sendMessage(socket, { content: 'The veto power has been unlocked! Now president or chancellor can veto any enacted policy!' })
+                phaseSocketEvents.startKillPhase(socket)
+            } else {
+                socketEventsUtils.resumeGame(socket, { delay: 3000, func: phaseSocketEvents.startChancellorChoicePhase })
+            }
+        },
+
+        enactPolicy: (socket, policy) => {
+            const isFacist = policy === PolicyCards.FacistPolicy
+            RoomsManager.enactPolicy(socket.currentRoom, policy)
+            socketEventsUtils.sendMessage(socket, { content: `A ${isFacist ? 'facist' : 'liberal'} policy has been enacted!` })
+            io.sockets.in(socket.currentRoom).emit(SocketEvents.NewPolicy, {
+                data: {
+                    policy,
+                },
+            })
+
+            const isVetoUnlocked = RoomsManager.isVetoUnlocked(socket.currentRoom)
+            if (isFacist && !isVetoUnlocked) policyLogic.checkForImmediateSuperpowersOrContinue(socket)
+        },
+    }
+
+    return policyLogic
+}

--- a/utils/SocketEventsUtils.js
+++ b/utils/SocketEventsUtils.js
@@ -74,41 +74,6 @@ const SocketEventsUtils = (io, RoomsManager) => {
             }
         },
 
-        enactPolicy: (socket, policy) => {
-            const isFacist = policy === PolicyCards.FacistPolicy
-            RoomsManager.enactPolicy(socket.currentRoom, policy)
-            socketEventsUtils.sendMessage(socket, { content: `A ${isFacist ? 'facist' : 'liberal'} policy has been enacted!` })
-            io.sockets.in(socket.currentRoom).emit(SocketEvents.NewPolicy, {
-                data: {
-                    policy,
-                },
-            })
-        },
-
-        updateTrackerPositionIfNecessary: (socket, isSuccess) => {
-            if (isSuccess) {
-                const trackerPosition = RoomsManager.getFailedElectionsCount(socket.currentRoom)
-                socketEventsUtils.resetElectionTracker(socket, trackerPosition)
-            } else {
-                RoomsManager.increaseFailedElectionsCount(socket.currentRoom)
-                socketEventsUtils.sendMessage(socket, { content: 'The failed elections tracker has increased!' })
-                const failedElectionsCount = RoomsManager.getFailedElectionsCount(socket.currentRoom)
-                if (failedElectionsCount >= 3) {
-                    socketEventsUtils.resetElectionTracker(socket, failedElectionsCount)
-
-                    const topCard = RoomsManager.takeChoicePolicyCards(socket.currentRoom, 1)[0]
-                    socketEventsUtils.enactPolicy(socket, topCard)
-
-                } else {
-                    io.sockets.in(socket.currentRoom).emit(SocketEvents.IncreaseTrackerPosition, {
-                        data: {
-                            timestamp: getCurrentTimestamp(),
-                        },
-                    })
-                }
-            }
-        },
-
         switchRooms: (socket, startRoom, targetRoom) => {
             if (startRoom) {
                 socket.leave(startRoom)

--- a/utils/SocketEventsUtils.js
+++ b/utils/SocketEventsUtils.js
@@ -85,7 +85,7 @@ const SocketEventsUtils = (io, RoomsManager) => {
             })
         },
 
-        checkIfTrackerPositionShouldUpdate: (socket, isSuccess) => {
+        updateTrackerPositionIfNecessary: (socket, isSuccess) => {
             if (isSuccess) {
                 const trackerPosition = RoomsManager.getFailedElectionsCount(socket.currentRoom)
                 socketEventsUtils.resetElectionTracker(socket, trackerPosition)


### PR DESCRIPTION
I reorganized functions into diffrent files as it was necessary to prevent circular refrence.
Superpowers now should work properly; Refactor however caused other issue, I found that at some point I had two president, one with active kill superpower, the other was chosing chancellor:
![twopresidentsonewithsuperpower](https://user-images.githubusercontent.com/17849844/40027487-89ff2e0e-57da-11e8-9d93-cb48a64100bd.png)
![dkilled-ewaspresident-afterkill-apresident](https://user-images.githubusercontent.com/17849844/40027492-8d02a5d6-57da-11e8-9ec4-191f93b2464c.png)
It happend because after superpower was triggered, the game was "resumed" with `startChancellorChoicePhase`, which shouldn't be triggered from state in which game was in (`GamePhases.GAME_PHASE_SUPERPOWER`). We need ASAP secure other functions from execution from incorrect states.