### PR TITLE
feat(): Make commit hash available on page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3930,9 +3930,9 @@
       }
     },
     "babel-jest": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.2.0.tgz",
-      "integrity": "sha1-FKnWo/QSLf6mBp03CFrfJqU6Tbo=",
+      "version": "23.4.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.4.2.tgz",
+      "integrity": "sha512-wg1LJ2tzsafXqPFVgAsYsMCVD5U7kwJZAvbZIxVm27iOewsQw1BR7VZifDlMTEWVo3wasoPPyMdKXWCsfFPr3Q==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "^4.1.6",
@@ -3940,14 +3940,15 @@
       }
     },
     "babel-loader": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
-      "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
+      "version": "8.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.0-beta.4.tgz",
+      "integrity": "sha512-fQMCj8jRpF/2CPuVnpFrOb8+8pRuquKqoC+tspy5RWBmL37/2qc104sLLLqpwWltrFzpYb30utPpKc3H6P3ETQ==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^1.0.0",
         "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1"
+        "mkdirp": "^0.5.1",
+        "util.promisify": "^1.0.0"
       }
     },
     "babel-messages": {
@@ -6574,9 +6575,9 @@
       "dev": true
     },
     "ejs": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
       "dev": true
     },
     "electron-releases": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "brotli-webpack-plugin": "0.5.0",
     "compression-webpack-plugin": "1.1.3",
     "css-loader": "0.26.4",
+    "ejs": "2.6.1",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "eslint": "4.15.0",

--- a/server.mjs
+++ b/server.mjs
@@ -1,24 +1,26 @@
 import path from 'path'
 import http from 'http'
 import Express from 'express'
+import ejs from 'ejs'
 import expressStaticGzip from 'express-static-gzip'
 import { initializeIO } from './io'
+import { getLatestGitCommitHash } from './utils/utils'
 
 // initialize the server and configure support for ejs templates
 const __dirname = path.dirname(new URL(import.meta.url).pathname)
 const app = new Express()
 const server = new http.Server(app)
+let gitVersionHash = ''
 
-// routes
+// view engine setup to ejs
+app.engine('html', ejs.renderFile)
+app.set('view engine', 'html')
 
-
-// view engine setup
-app.set('views', path.join(__dirname, 'views'))
 // socket.io
 initializeIO(server)
 
 app.get('/', (req, res) => {
-    return res.sendFile('index.html', { root: `${__dirname}/views` })
+    return res.render('index.html', { gitVersionHash })
 })
 
 app.use(expressStaticGzip(path.join(__dirname, '/public'), {
@@ -29,7 +31,7 @@ app.use(expressStaticGzip(path.join(__dirname, '/public'), {
 app.get('*', (req, res, next) => {
     res.status(404)
     console.log(`404! Page not found! Original url: ${req.originalUrl}`)
-    return res.sendFile('index.html', { root: `${__dirname}/views` })
+    return res.render('index.html', { gitVersionHash })
 })
 
 // start the server
@@ -40,4 +42,5 @@ server.listen(port, err => {
         return console.error(err)
     }
     console.info(`Server running on http://localhost:${port} [${env}]`)
+    gitVersionHash = getLatestGitCommitHash()
 })

--- a/utils/utils.mjs
+++ b/utils/utils.mjs
@@ -1,10 +1,15 @@
 import moment from 'moment'
+import childProcess from 'child_process'
 import lodash from 'lodash'
 import { MessagesTypes } from '../Dictionary'
 
 const { pad } = lodash
 
 const getCurrentTimestamp = () => Math.floor(Date.now() / 1000)
+
+const getLatestGitCommitHash = () => childProcess
+    .execSync('git rev-parse HEAD')
+    .toString().trim().slice(0, 7);
 
 const log = ({ currentRoom, currentPlayerName }, messageType, message) => {
     if (process.env.NODE_HIDECONSOLE) return
@@ -17,6 +22,7 @@ const logError = (contextData, message) => log(contextData, MessagesTypes.ERROR,
 
 export {
     getCurrentTimestamp,
+    getLatestGitCommitHash,
     log,
     logInfo,
     logError,

--- a/views/index.html
+++ b/views/index.html
@@ -2,6 +2,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="git-version-hash" content="<%= gitVersionHash %>">
     <title>SecretSzanta</title>
     <link href="https://fonts.googleapis.com/css?family=Alegreya" rel="stylesheet">
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">


### PR DESCRIPTION
This PR closes #173

- add ejs as template engine for node again,
- add git-version-hash as a way for developers to see which version the server is running.