### PR TITLE
fix(): Fix hover and showing of fascist avatar in submenu

### DIFF
--- a/src/features/PlayerBoard/Player/PlayerAvatar/PlayerAvatar.css
+++ b/src/features/PlayerBoard/Player/PlayerAvatar/PlayerAvatar.css
@@ -24,19 +24,15 @@
 
 .avatarWrapper {
     position: relative;
-    &:hover {
-        & .portrait {
-            &.facist-portrait {
-                opacity: 0.1; 
-            }
-        }
+    &:hover .fascistPortrait {
+        opacity: 0.1; 
     }
 }
 
 .portrait {
     width: var(--player-image-width);
     max-width: 130px;
-    &.facistPortrait {
+    &.fascistPortrait {
         position: absolute;
         height: 100%;
         width: 100%;
@@ -44,7 +40,6 @@
         z-index: 1;
     }
 }
-
 .selectingWaitIcon {
     color: var(--selecting-wait-icon-color);
     position: absolute;

--- a/src/features/PlayerBoard/Player/PlayerAvatar/PlayerAvatar.jsx
+++ b/src/features/PlayerBoard/Player/PlayerAvatar/PlayerAvatar.jsx
@@ -15,7 +15,7 @@ const PlayerAvatar = ({
     className,
 }) => {
     const liberalAvatarPicture = getAvatar(`liberal-${liberalAvatar}`)
-    const facistAvatarPicture = getAvatar(`fascist-${fascistAvatar}`)
+    const fascistAvatarPicture = getAvatar(`fascist-${fascistAvatar}`)
 
     if (!liberalAvatarPicture) {
         return null
@@ -25,7 +25,7 @@ const PlayerAvatar = ({
         <div className={classNames(styles.avatarWrapper, className, { [styles.dead]: isDead })}>
             {isOwner && <Icon name="fa-bolt" className={styles.ownerIcon} />}
             {isPlayerWaitedFor && <Icon name="fa-clock-o" className={styles.selectingWaitIcon} />}
-            {fascistAvatar && <img className={classNames(styles.portrait, styles.facistPortrait)} src={facistAvatarPicture} alt="Player facist avatar" />}
+            {fascistAvatar && <img className={classNames(styles.portrait, styles.fascistPortrait)} src={fascistAvatarPicture} alt="Player fascist avatar" />}
             <img className={styles.portrait} src={liberalAvatarPicture} alt="Player liberal avatar" />
         </div>
     )

--- a/src/features/PlayerBoard/Player/PlayerAvatar/__tests__/__snapshots__/PlayerAvatar.test.js.snap
+++ b/src/features/PlayerBoard/Player/PlayerAvatar/__tests__/__snapshots__/PlayerAvatar.test.js.snap
@@ -25,8 +25,8 @@ exports[`<PlayerAvatar /> shows liberal avatar, fascist avatar, owner icon, wait
     className="fa fa-clock-o selectingWaitIcon"
   />
   <img
-    alt="Player facist avatar"
-    className="portrait facistPortrait"
+    alt="Player fascist avatar"
+    className="portrait fascistPortrait"
     src="test-file-stub"
   />
   <img

--- a/src/features/UIBox/Submenu/Submenu.jsx
+++ b/src/features/UIBox/Submenu/Submenu.jsx
@@ -38,7 +38,7 @@ const mapStateToProps = ({ user, room }) => {
         affiliation: get(player, 'affiliation'),
         isAffiliationHidden: user.isAffiliationHidden,
         role: get(player, 'role'),
-        facistAvatar: get(player, 'facistAvatar'),
+        fascistAvatar: get(player, 'facistAvatar'),
         liberalAvatar: get(player, 'avatarNumber'),
         isOwner: room.ownerName === user.userName,
         isDead: get(player, 'isDead'),


### PR DESCRIPTION
This PR closes #177:

- fixes hover effect on submenu avatar (for fascist, hovering should make avatar opaque),
- fixes showing of fascist avatar in submenu