### PR TITLE
feat(#178): Don't scroll chat if user himself has moved up

### DIFF
--- a/src/features/Chat/MessagesBox/MessagesBox.js
+++ b/src/features/Chat/MessagesBox/MessagesBox.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import MessagesBoxComponent from './MessagesBoxComponent'
 
+const MESSAGE_HEIGHT = 25
+
 export class MessagesBox extends React.PureComponent {
     static displayName = 'MessagesBox'
     static propTypes = {
@@ -16,7 +18,14 @@ export class MessagesBox extends React.PureComponent {
     }
 
     componentDidUpdate() {
-        this.scrollToBottomOfMessages()
+        const { current } = this.messagesBoxRef
+        if (current) {
+            // We calculate if the user has reached the end - MESSAGE_HEIGHT, because it happens in componentDidUpdate
+            // and by this time, a new message must have been added to the box, so we need to subtract that
+            if (current.scrollHeight - (current.offsetHeight + current.scrollTop) <= MESSAGE_HEIGHT) {
+                this.scrollToBottomOfMessages()
+            }
+        }
     }
 
     scrollToBottomOfMessages = () => {

--- a/src/features/Chat/MessagesBox/__tests__/MessagesBox.test.js
+++ b/src/features/Chat/MessagesBox/__tests__/MessagesBox.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { aMessage, arrayOf } from 'packages/factories'
-import { expectMatchingSnapshot } from 'packages/testUtils'
 import { MessagesBox } from '../MessagesBox'
 
 const setupProps = (propsOverrides = {}, renderMethod = shallow) => {
@@ -14,11 +13,33 @@ const setupProps = (propsOverrides = {}, renderMethod = shallow) => {
 }
 
 describe('<MessagesBox />', () => {
-    it('calls scrollToBottomOfMessages on each update', () => {
+    it('calls scrollToBottomOfMessages on each update if user has scrolled to bottom already', () => {
         const { props, component } = setupProps()
-        const instance = component.instance();
+        const instance = component.instance()
         instance.scrollToBottomOfMessages = jest.fn()
+        instance.messagesBoxRef = {
+            current: {
+                scrollHeight: 200,
+                offsetHeight: 100,
+                scrollTop: 78,
+            },
+        }
         component.setProps({ messages: [...props.messages, aMessage()] })
         expect(instance.scrollToBottomOfMessages).toHaveBeenCalled()
+    })
+
+    it('doesnt call scrollToBottomOfMessages if user has not scrolled to the bottom of chat', () => {
+        const { props, component } = setupProps()
+        const instance = component.instance()
+        instance.scrollToBottomOfMessages = jest.fn()
+        instance.messagesBoxRef = {
+            current: {
+                scrollHeight: 200,
+                offsetHeight: 100,
+                scrollTop: 30,
+            },
+        }
+        component.setProps({ messages: [...props.messages, aMessage()] })
+        expect(instance.scrollToBottomOfMessages).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
In this PR:
- new behavior for chat box:
- - if user goes to the bottom of chat, each message will move the chat window to bottom (so newest messages are always shown),
- - if user for some reason scrolled up (for ex. to copy nickname of a player or to read something), new messages will not trigger scrolling down until he scrolls himself down