### PR TITLE
Fix(#222): Fix postcss variables and eslint imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,8 +7,14 @@
     ],
     "settings": {
         "import/resolver": {
-            "node": { "extensions": [".js", ".mjs"] }
-        }
+            "node": { "extensions": [".js", ".mjs"] },
+            "alias": {
+                "map": [
+                    ['packages', './src/packages'],
+                ],
+                extensions: ['.js'],
+            },
+        },
     },
     "rules": {
         "max-len": ["error", { "code": 120 }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5155,6 +5155,12 @@
         "object.entries": "^1.0.4"
       }
     },
+    "eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
+      "dev": true
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -6514,13 +6520,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6543,7 +6551,8 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -6710,6 +6719,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "enzyme-adapter-react-16": "1.7.1",
     "eslint": "5.11.0",
     "eslint-config-airbnb": "17.1.0",
+    "eslint-import-resolver-alias": "1.1.2",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "22.1.2",
     "eslint-plugin-jsx-a11y": "6.1.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -7,6 +7,9 @@ module.exports = {
             features: {
                 'nesting-rules': true,
                 'custom-media-queries': true,
+                'custom-properties': {
+                    preserve: false,
+                },
             },
             stage: 2,
             browsers: 'last 2 versions',


### PR DESCRIPTION
- fixed eslint crying about absolute imports to aliased packages not being available,
- fix for css-modules variables littering browser :root,
- resolves #222 